### PR TITLE
Clarify what the links in logs.ytag are for.

### DIFF
--- a/tags/guide/logs.ytag
+++ b/tags/guide/logs.ytag
@@ -12,5 +12,6 @@ Please make sure to upload these logs to a paste site instead of uploading the f
 
 Do not copy and paste, screenshot, or significantly alter your logs.
 
+Where to find your logs:
 **»** [Windows/Linux](https://fabricmc.net/wiki/player:tutorials:logs_ml:windows)
 **»** [macOS](https://fabricmc.net/wiki/player:tutorials:logs_ml:mac)


### PR DESCRIPTION
The links at the bottom of logs.ytag indicate where to find your logs, however, the bot message does not specify that that is what they are for exactly and are thus sometimes overlooked.